### PR TITLE
Issue#68: Add the feature to create groups from the steam-shell

### DIFF
--- a/tools/steam-shell.pike
+++ b/tools/steam-shell.pike
@@ -52,6 +52,8 @@ create          Create an object (File/Container/Exit). Provide the full path of
 peek            Peek through a container.
 inventory(i)    List your inventory.
 edit            Edit a file in the current Room.
+join            Join a group.
+leave           Leave a group.
 group           Use group commands. (list/join/leave)
 hilfe           Help for Hilfe commands.
 ";
@@ -95,8 +97,14 @@ hilfe           Help for Hilfe commands.
     case "edit":
       write("Edit a file in the current Room.\n");
       return;
+    case "join":
+      write("Join a group.\n");
+      return;
+    case "leave":
+      write("Leave a group.\n");
+      return;
     case "group":
-      write("Use group commands. (list/join/leave)");
+      write("Use group commands. (list/join/leave)\n");
       return;
     //Hilfe internal help
     case "me more":
@@ -220,6 +228,8 @@ int main(int argc, array(string) argv)
     "inventory"   : inventory,
     "i"           : inventory,
     "edit"        : editfile,
+    "join"        : join,
+    "leave"       : leave,
     "group"       : group,
     ]);
 //  Regexp.SimpleRegexp a = Regexp.SimpleRegexp("[a-zA-Z]* [\"|'][a-zA-Z _-]*[\"|']");
@@ -363,6 +373,8 @@ mapping assign(object conn, object _Server, object users)
     "look"        : look,
     "take"        : take,
     "gothrough"   : gothrough,
+    "join"        : join,
+    "leave"       : leave,
     "group"       : group,
 
     // from database.h :
@@ -421,9 +433,34 @@ void group(string command,void|string name)
       write("%-$*s\n", screenwidth,toappend);
       write("\n");
       return;
-    case "join":
-      if(!stringp(name)){
-        write("group join <name of the group>");
+    default:
+      write("Group command: list/join/leave\n");
+  }
+}
+
+void leave(string what,void|string name)
+{
+  if(what=="group")
+  {
+    if(!stringp(name)){
+        write("leave group <group name>\n");
+        return;
+      }
+      object group = _Server->get_module("groups")->get_group(name);
+      if(group == 0){
+        write("The group does not exists\n");
+        return;
+      }
+      group->remove_member(me);
+  }
+}
+
+void join(string what,void|string name)
+{
+  if(what=="group")
+  {
+    if(!stringp(name)){
+        write("join group <name of the group>\n");
         return;
       }
       object group = _Server->get_module("groups")->get_group(name);
@@ -442,24 +479,8 @@ void group(string command,void|string name)
         case -2:write("pending failed");
           break;
       }
-      return;
-    case "leave":
-      if(!stringp(name)){
-        write("group leave <group name>");
-        return;
-      }
-      group = _Server->get_module("groups")->get_group(name);
-      if(group == 0){
-        write("The group does not exists\n");
-        return;
-      }
-      group->remove_member(me);
-      return;
-    default:
-      write("Group command: list/join/leave\n");
   }
 }
-
 
 // create new sTeam objects
 // with code taken from the web script create.pike

--- a/tools/steam-shell.pike
+++ b/tools/steam-shell.pike
@@ -444,6 +444,16 @@ void group(string command,void|string name)
       }
       return;
     case "leave":
+      if(!stringp(name)){
+        write("group leave <group name>");
+        return;
+      }
+      group = _Server->get_module("groups")->get_group(name);
+      if(group == 0){
+        write("The group does not exists\n");
+        return;
+      }
+      group->remove_member(me);
       return;
     default:
       write("Group command: list/join/leave\n");

--- a/tools/steam-shell.pike
+++ b/tools/steam-shell.pike
@@ -580,9 +580,19 @@ array(string) get_list(string what,string|object|void lpath)
     break;
     case "exits":
     case "gates":
+    {
+      mixed all = pathobj->get_inventory_by_class(CLASS_EXIT);
+      foreach(all, object obj)
+      {
+        string fact_name = _Server->get_factory(obj)->query_attribute("OBJ_NAME");
+        string obj_name = obj->query_attribute("OBJ_NAME");
+        whatlist = Array.push(whatlist,obj_name);
+      }
+    }
+    break;
     case "rooms":
     {
-      mixed all = pathobj->get_inventory_by_class(CLASS_ROOM|CLASS_EXIT);
+      mixed all = pathobj->get_inventory_by_class(CLASS_ROOM);
       foreach(all, object obj)
       {
         string fact_name = _Server->get_factory(obj)->query_attribute("OBJ_NAME");

--- a/tools/steam-shell.pike
+++ b/tools/steam-shell.pike
@@ -48,7 +48,7 @@ room            Describe the Room you are currently in.
 look            Look around the Room.
 take            Copy a object in your inventory.
 gothrough       Go through a gate.
-create          Create an object (File/Container/Exit) in current Room.
+create          Create an object (File/Container/Exit). Provide the full path of the destination or a . if you want it in current folder.
 peek            Peek through a container.
 inventory(i)    List your inventory.
 edit            Edit a file in the current Room.
@@ -82,7 +82,7 @@ hilfe           Help for Hilfe commands.
       write("Go through a gate.\n");
       return;
     case "create":
-      write("Create an object (File/Container/Exit) in current Room.\n");
+      write("Create an object (File/Container/Exit). Provide the full path of the destination or a . if you want it in current folder.\n");
       return;
     case "peek":
       write("Peek through a container.\n");
@@ -240,6 +240,8 @@ int main(int argc, array(string) argv)
           myarray[command_arr[0]](command_arr[1],command_arr[2]);
         else if(num==1)
           myarray[command_arr[0]]();
+        else if(num==4)
+          myarray[command_arr[0]](command_arr[1],command_arr[2],command_arr[3]);
         };
 
         if(result!=0)
@@ -668,7 +670,7 @@ int delete(string file_cont_name)
   return 0;
 }
 
-int create_ob(string type,string name)
+int create_ob(string type,string name,string destination)
 {
   string desc = readln->read("How would you describe it?\n");
   mapping data = ([]);
@@ -685,8 +687,12 @@ int create_ob(string type,string name)
     data = ([ "link_to":link_to ]);
   }
   object myobj = create_object(type,name,desc,data);
-  if(type=="Room" || type=="Container")
-    myobj->move(OBJ(getpath()));
+  if(type=="Room" || type=="Container"){
+    if(destination==".")
+      myobj->move(OBJ(getpath()));
+    else
+      myobj->move(OBJ(destination));
+  }
   
 
   return 0;

--- a/tools/steam-shell.pike
+++ b/tools/steam-shell.pike
@@ -702,8 +702,9 @@ int create_ob(string type,string name)
     data = ([ "link_to":link_to ]);
   }
   object myobj = create_object(type,name,desc,data);
-  if(type=="Room")
+  if(type=="Room" || type=="Container")
     myobj->move(OBJ(getpath()));
+  
 
   return 0;
 }

--- a/tools/steam-shell.pike
+++ b/tools/steam-shell.pike
@@ -402,6 +402,7 @@ mapping assign(object conn, object _Server, object users)
     ]);
 }
 
+//Command to leave an object. Currently implemented for groups can be extended to rooms
 void leave(string what,void|string name)
 {
   if(what=="group")
@@ -419,6 +420,8 @@ void leave(string what,void|string name)
   }
 }
 
+
+//command to join an object. currently implemented for groups.
 void join(string what,void|string name)
 {
   if(what=="group")

--- a/tools/steam-shell.pike
+++ b/tools/steam-shell.pike
@@ -675,11 +675,13 @@ int create_ob(string type,string name,string destination)
   string desc = readln->read("How would you describe it?\n");
   mapping data = ([]);
   type = String.capitalize(type);
+  if(destination == ".")
+    destination = getpath();
   if(type=="Exit")
   {
     object exit_to = OBJ(readln->read("Where do you want to exit to?(full path)\n"));
-    object exit_from = OBJ(getpath());
-    data = ([ "exit_from":exit_from, "exit_to":exit_to ]);
+//    object exit_from = OBJ(getpath());
+    data = ([ "exit_from":OBJ(destination), "exit_to":exit_to ]);
   }
   else if(type=="Link")
   {
@@ -687,13 +689,15 @@ int create_ob(string type,string name,string destination)
     data = ([ "link_to":link_to ]);
   }
   object myobj = create_object(type,name,desc,data);
-  if(type=="Room" || type=="Container"){
+/*  if(type=="Room" || type=="Container"){
     if(destination==".")
       myobj->move(OBJ(getpath()));
     else
       myobj->move(OBJ(destination));
   }
-  
+ */
+  if(!(type == "Exit"))
+    myobj->move(OBJ(destination));
 
   return 0;
 }

--- a/tools/steam-shell.pike
+++ b/tools/steam-shell.pike
@@ -548,16 +548,8 @@ int goto_room(string where)
     pathobj = OBJ(where);
     if(!pathobj)    //Relative room checking
     {
-      if(getpath()[-1]==47)    //check last "/"
-      {
-        pathobj = OBJ(getpath()+where);
-        where=getpath()+where;
-      }
-      else
-      {
-        pathobj = OBJ(getpath()+"/"+where);
-        where=getpath()+"/"+where;
-      }
+      pathobj = OBJ(getpath()+"/"+where);
+      where=getpath()+"/"+where;
     }
     roomname = pathobj->query_attribute("OBJ_NAME");
     string factory = _Server->get_factory(pathobj)->query_attribute("OBJ_NAME");
@@ -628,10 +620,7 @@ int look(string|void str)
 int take(string name)
 {
     string fullpath="";
-    if(getpath()[-1]==47)    //check last "/"
-      fullpath = getpath()+name;
-    else
-      fullpath = getpath()+"/"+name;
+    fullpath = getpath()+"/"+name;
     object orig_file = OBJ(fullpath);
     if(orig_file)
     {
@@ -647,10 +636,7 @@ int take(string name)
 int gothrough(string gatename)
 {
     string fullpath = "";
-    if(getpath()[-1]==47)    //check last "/"
-      fullpath = getpath()+gatename;
-    else
-      fullpath = getpath()+"/"+gatename;
+    fullpath = getpath()+"/"+gatename;
     object gate = OBJ(fullpath);
     if(gate)
     {
@@ -676,10 +662,7 @@ int gothrough(string gatename)
 int delete(string file_cont_name)
 {
   string fullpath="";
-  if(getpath()[-1]==47)    //check last "/"
-      fullpath = getpath()+file_cont_name;
-  else
-      fullpath = getpath()+"/"+file_cont_name;
+  fullpath = getpath()+"/"+file_cont_name;
   if(OBJ(fullpath))
     return 0;
   return 0;
@@ -712,10 +695,7 @@ int create_ob(string type,string name)
 int peek(string container)
 {
   string fullpath = "";
-  if(getpath()[-1]==47)    //check last "/"
-      fullpath = getpath()+container;
-  else
-      fullpath = getpath()+"/"+container;
+  fullpath = getpath()+"/"+container;
   string pathfact = _Server->get_factory(OBJ(fullpath))->query_attribute("OBJ_NAME");
   if(pathfact=="Room.factory")
   {
@@ -763,10 +743,7 @@ int inventory()
 int editfile(string filename)
 {
   string fullpath = "";
-  if(getpath()[-1]==47)    //check last "/"
-      fullpath = getpath()+filename;
-  else
-      fullpath = getpath()+"/"+filename;
+  fullpath = getpath()+"/"+filename;
   string pathfact = _Server->get_factory(OBJ(fullpath))->query_attribute("OBJ_NAME");
   if(pathfact=="Document.factory")
     applaunch(OBJ(fullpath),exitnow);


### PR DESCRIPTION
Fixes #68 .
Groups can be created using the create command as create group <group_name>.
For other group functions group command is present with three options list, join, leave.
Their respective syntax is.
group list
group join <group_name>
group leave <group_name>
